### PR TITLE
A couple of fixes

### DIFF
--- a/src/Http/Controllers/ClearController.php
+++ b/src/Http/Controllers/ClearController.php
@@ -2,9 +2,9 @@
 
 namespace DoubleThreeDigital\StaticCacheManager\Http\Controllers;
 
-use Statamic\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\File;
+use Statamic\Support\Str;
 
 class ClearController
 {
@@ -21,7 +21,7 @@ class ClearController
 
     protected function delete($path)
     {
-        $path = config('statamic.static_caching.strategies.full.path') . Str::ensureLeft($path, '/');
+        $path = config('statamic.static_caching.strategies.full.path').Str::ensureLeft($path, '/');
 
         if (File::isDirectory($path)) {
             $this->deleteDirectory($path);
@@ -40,7 +40,7 @@ class ClearController
             return;
         }
 
-        File::delete($path . '_.html');
+        File::delete($path.'_.html');
     }
 
     protected function deleteDirectory($path)

--- a/src/Http/Controllers/ClearController.php
+++ b/src/Http/Controllers/ClearController.php
@@ -2,9 +2,9 @@
 
 namespace DoubleThreeDigital\StaticCacheManager\Http\Controllers;
 
+use Statamic\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\File;
-use Illuminate\Support\Str;
 
 class ClearController
 {
@@ -21,13 +21,13 @@ class ClearController
 
     protected function delete($path)
     {
-        $staticCachePath = config('statamic.static_caching.strategies.full.path');
+        $path = config('statamic.static_caching.strategies.full.path') . Str::ensureLeft($path, '/');
 
-        if (File::isDirectory($staticCachePath.'/'.$path)) {
-            return $this->deleteDir($staticCachePath.'/'.$path);
+        if (File::isDirectory($path)) {
+            $this->deleteDirectory($path);
         }
 
-        return $this->deleteFile($staticCachePath.'/'.$path);
+        $this->deleteFile($path);
     }
 
     protected function deleteFile($path)
@@ -40,10 +40,10 @@ class ClearController
             return;
         }
 
-        File::delete($path);
+        File::delete($path . '_.html');
     }
 
-    protected function deleteDir($path)
+    protected function deleteDirectory($path)
     {
         return File::deleteDirectory($path);
     }


### PR DESCRIPTION
I've been using this addon on a site of mine and noticed a couple of bugs so thought I'd fix them:

* When you enter a path, you couldn't previously start it with a `/` or it wouldn't do anything #8
* If you were wanting to clear a cached file like `whats-on_.html`, entering `whats-on` wouldn't do anything because it would look for the wrong path (`whats-on`, instead of `whats-on_.html`)

I'm going to release these changes under a new version (v1.1) in case it introduces any breaking changes. It's also been a long time since the last release 😅 