### PR TITLE
Clear versions of pages with query parameters

### DIFF
--- a/src/Http/Controllers/ClearController.php
+++ b/src/Http/Controllers/ClearController.php
@@ -19,7 +19,7 @@ class ClearController
         return redirect()->back();
     }
 
-    protected function delete($path)
+    protected function delete($path): void
     {
         $path = config('statamic.static_caching.strategies.full.path') . Str::ensureLeft($path, '/');
 
@@ -30,7 +30,7 @@ class ClearController
         $this->deleteFile($path);
     }
 
-    protected function deleteFile($path)
+    protected function deleteFile($path): void
     {
         if (! Str::of($path)->contains('*')) {
             $path .= '_*';
@@ -41,8 +41,8 @@ class ClearController
         }
     }
 
-    protected function deleteDirectory($path)
+    protected function deleteDirectory($path): void
     {
-        return File::deleteDirectory($path);
+        File::deleteDirectory($path);
     }
 }

--- a/src/Http/Controllers/ClearController.php
+++ b/src/Http/Controllers/ClearController.php
@@ -21,7 +21,7 @@ class ClearController
 
     protected function delete($path)
     {
-        $path = config('statamic.static_caching.strategies.full.path').Str::ensureLeft($path, '/');
+        $path = config('statamic.static_caching.strategies.full.path') . Str::ensureLeft($path, '/');
 
         if (File::isDirectory($path)) {
             $this->deleteDirectory($path);
@@ -32,15 +32,13 @@ class ClearController
 
     protected function deleteFile($path)
     {
-        if (Str::of($path)->contains('*')) {
-            foreach (File::glob($path) as $file) {
-                File::delete($file);
-            }
-
-            return;
+        if (! Str::of($path)->contains('*')) {
+            $path .= '_*';
         }
 
-        File::delete($path.'_.html');
+        foreach (File::glob($path) as $file) {
+            File::delete($file);
+        }
     }
 
     protected function deleteDirectory($path)


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request fixes an issue where versions of a page with query parameters would not have previously been cleared.

Fixes #10.